### PR TITLE
Style: html semantitag 적용

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,229 +1,213 @@
 <!DOCTYPE html>
 <html lang="ko">
-  <head>
-    <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="style/style.css" />
-    <title>8조</title>
 
-    <style>
-      .container {
-        width: 1280px;
-        margin: auto;
-      }
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="style/style.css" />
+  <title>8조</title>
 
-      .inner2 {
-        display: flex;
-        justify-content: space-between;
-      }
+  <style>
+    .container {
+      width: 1280px;
+      margin: auto;
+    }
 
-      .inner2-1 {
-        width: 830px;
-      }
+    main {
+      display: flex;
+      justify-content: space-between;
+    }
 
-      .inner2-2 {
-        width: 420px;
-      }
-    </style>
-    <link rel="stylesheet" href="style/style.css" />
-  </head>
+    .section-aside {
+      width: 420px;
+    }
+  </style>
+  <link rel="stylesheet" href="style/style.css" />
+</head>
 
-  <body>
-    <div class="container">
-      <div class="inner1">
-        <header class="header">
-          <div class="search">
-            <h1 class="search-logo">
-              <a href="https://www.naver.com">
-                <svg
-                  viewBox="0 0 24 24"
-                  fill="#000"
-                  xmlns="http://www.w3.org/2000/svg%22%3E"
-                >
-                  <path
-                    d="M16.273 12.845 7.376 0H0v24h7.727V11.155L16.624 24H24V0h-7.727v12.845z"
-                  ></path>
-                </svg>
-              </a>
-            </h1>
-            <form action="">
-              <input
-                id="search-input"
-                class="search-input"
-                type="text"
-                placeholder="검색어를 입력해 주세요."
-              />
-              <div class="search__button--group">
-                <button type="button" class="keyboard-btn">
-                  <span class="btn-inner blind">입력도구</span>
-                </button>
-                <button type="button" class="recent-btn">
-                  <span class="btn-inner blind">최근 검색어</span>
-                </button>
-                <button type="button" class="search-btn">
-                  <span class="btn-inner blind">검색버튼</span>
+<body>
+  <div class="container">
+    <header class="header">
+      <div class="search">
+        <h1 class="search-logo">
+          <a href="https://www.naver.com">
+            <svg viewBox="0 0 24 24" fill="#000" xmlns="http://www.w3.org/2000/svg%22%3E">
+              <path d="M16.273 12.845 7.376 0H0v24h7.727V11.155L16.624 24H24V0h-7.727v12.845z"></path>
+            </svg>
+          </a>
+        </h1>
+        <form action="">
+          <input id="search-input" class="search-input" type="text" placeholder="검색어를 입력해 주세요." />
+          <div class="search__button--group">
+            <button type="button" class="keyboard-btn">
+              <span class="btn-inner blind">입력도구</span>
+            </button>
+            <button type="button" class="recent-btn">
+              <span class="btn-inner blind">최근 검색어</span>
+            </button>
+            <button type="button" class="search-btn">
+              <span class="btn-inner blind">검색버튼</span>
+            </button>
+          </div>
+        </form>
+      </div>
+      <div class="two" id="nav">
+        <ul class="serviceList">
+          <li class="serviceList__item">
+            <a href="#" class="serviceList__link">
+              <div class="serviceList__icon serviceList__icon--mail"></div>
+              <span class="serviceList__name">메일</span>
+            </a>
+          </li>
+          <li class="serviceList__item">
+            <a href="#" class="serviceList__link">
+              <div class="serviceList__icon serviceList__icon--cafe"></div>
+              <span class="serviceList__name">카페</span>
+            </a>
+          </li>
+          <li class="serviceList__item">
+            <a href="#" class="serviceList__link">
+              <div class="serviceList__icon serviceList__icon--blog"></div>
+              <span class="serviceList__name">블로그</span>
+            </a>
+          </li>
+          <li class="serviceList__item">
+            <a href="#" class="serviceList__link">
+              <div class="serviceList__icon serviceList__icon--shopping"></div>
+              <span class="serviceList__name">쇼핑</span>
+            </a>
+          </li>
+          <li class="serviceList__item">
+            <a href="#" class="serviceList__link">
+              <div class="serviceList__icon serviceList__icon--news"></div>
+              <span class="serviceList__name">뉴스</span>
+            </a>
+          </li>
+          <li class="serviceList__item">
+            <a href="#" class="serviceList__link">
+              <div class="serviceList__icon serviceList__icon--stock"></div>
+              <span class="serviceList__name">증권</span>
+            </a>
+          </li>
+          <li class="serviceList__item">
+            <a href="#" class="serviceList__link">
+              <div class="serviceList__icon serviceList__icon--real"></div>
+              <span class="serviceList__name">부동산</span>
+            </a>
+          </li>
+          <li class="serviceList__item">
+            <a href="#" class="serviceList__link">
+              <div class="serviceList__icon serviceList__icon--map"></div>
+              <span class="serviceList__name">지도</span>
+            </a>
+          </li>
+          <li class="serviceList__item">
+            <a href="#" class="serviceList__link">
+              <div class="serviceList__icon serviceList__icon--webtoon"></div>
+              <span class="serviceList__name">웹툰</span>
+            </a>
+          </li>
+          <li class="serviceList__item">
+            <a href="#" class="serviceList__link">
+              <div class="serviceList__icon serviceList__icon--more"></div>
+              <span class="serviceList__name serviceList__name--blind">바로가기 펼침</span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </header>
+
+    <main>
+      <section class="three news">
+        <ul class="news__companies">
+          <li><a href="#">Korea JoongAng Daily</a></li>
+          <li><a href="#">국민일보</a></li>
+          <li><a href="#">MBN</a></li>
+          <li><a href="#">YTN</a></li>
+          <li><a href="#">스포츠조선</a></li>
+          <li><a href="#">노컷뉴스</a></li>
+          <li><a href="#">스포츠서울</a></li>
+          <li><a href="#">NewDaily</a></li>
+          <li><a href="#">미디어오늘</a></li>
+          <li><a href="#">한국일보</a></li>
+          <li><a href="#">서울신문</a></li>
+          <li><a href="#">시사IN</a></li>
+        </ul>
+        <div class="news__paging">
+          <button class="btn-prev">
+            <span class="a11y-hidden">이전 페이지</span>
+          </button>
+          <a class="logo">
+            <div class="img-logo" aria-label="네이버 로고"></div>
+          </a>
+          <button class="btn-next">
+            <span class="a11y-hidden">다음 페이지</span>
+          </button>
+        </div>
+      </section>
+      <section class="section-aside">
+        <article class="account">
+          <p class="account__title">
+            네이버를 더 안전하고 편리하게 이용하세요
+          </p>
+          <h2 class="blind">NAVER 로그인</h2>
+          <a class="account__login"><i></i> 로그인</a>
+          <ul class="account__find">
+            <li><a href="#">아이디 찾기</a></li>
+            <li><a href="#">비밀번호 찾기</a></li>
+            <li><a href="#">회원가입</a></li>
+          </ul>
+        </article>
+        <article class="widgetboard">
+          <h2 class="widgetboard__title">위젯 보드</h2>
+          <section class="widgetboard__memo">
+            <header class="memo__header">
+              <h3><a href="#">메모</a></h3>
+              <div class="memo__lock-button">
+                <button type="button">
+                  <i>
+                    <span class="blind">메모잠금</span>
+                  </i>
+                  <div class="memo__lock-button-tooltip">메모 잠그기</div>
                 </button>
               </div>
-            </form>
-          </div>
-        </header>
-
-        <div class="two" id="nav">
-          <ul class="serviceList">
-            <li class="serviceList__item">
-              <a href="#" class="serviceList__link">
-                <div class="serviceList__icon serviceList__icon--mail"></div>
-                <span class="serviceList__name">메일</span>
-              </a>
-            </li>
-            <li class="serviceList__item">
-              <a href="#" class="serviceList__link">
-                <div class="serviceList__icon serviceList__icon--cafe"></div>
-                <span class="serviceList__name">카페</span>
-              </a>
-            </li>
-            <li class="serviceList__item">
-              <a href="#" class="serviceList__link">
-                <div class="serviceList__icon serviceList__icon--blog"></div>
-                <span class="serviceList__name">블로그</span>
-              </a>
-            </li>
-            <li class="serviceList__item">
-              <a href="#" class="serviceList__link">
-                <div
-                  class="serviceList__icon serviceList__icon--shopping"
-                ></div>
-                <span class="serviceList__name">쇼핑</span>
-              </a>
-            </li>
-            <li class="serviceList__item">
-              <a href="#" class="serviceList__link">
-                <div class="serviceList__icon serviceList__icon--news"></div>
-                <span class="serviceList__name">뉴스</span>
-              </a>
-            </li>
-            <li class="serviceList__item">
-              <a href="#" class="serviceList__link">
-                <div class="serviceList__icon serviceList__icon--stock"></div>
-                <span class="serviceList__name">증권</span>
-              </a>
-            </li>
-            <li class="serviceList__item">
-              <a href="#" class="serviceList__link">
-                <div class="serviceList__icon serviceList__icon--real"></div>
-                <span class="serviceList__name">부동산</span>
-              </a>
-            </li>
-            <li class="serviceList__item">
-              <a href="#" class="serviceList__link">
-                <div class="serviceList__icon serviceList__icon--map"></div>
-                <span class="serviceList__name">지도</span>
-              </a>
-            </li>
-            <li class="serviceList__item">
-              <a href="#" class="serviceList__link">
-                <div class="serviceList__icon serviceList__icon--webtoon"></div>
-                <span class="serviceList__name">웹툰</span>
-              </a>
-            </li>
-            <li class="serviceList__item">
-              <a href="#" class="serviceList__link">
-                <div class="serviceList__icon serviceList__icon--more"></div>
-                <span class="serviceList__name serviceList__name--blind"
-                  >바로가기 펼침</span
-                >
-              </a>
-            </li>
-          </ul>
-        </div>
-      </div>
-      <div class="inner2">
-        <section class="three news">
-          <div class="news__companies">
-            <article><a>Korea JoongAng Daily</a></article>
-            <article><a>국민일보</a></article>
-            <article><a>MBN</a></article>
-            <article><a>YTN</a></article>
-            <article><a>스포츠조선</a></article>
-            <article><a>노컷뉴스</a></article>
-            <article><a>스포츠서울</a></article>
-            <article><a>NewDaily</a></article>
-            <article><a>미디어오늘</a></article>
-            <article><a>한국일보</a></article>
-            <article><a>서울신문</a></article>
-            <article><a>시사IN</a></article>
-          </div>
-          <div class="news__paging">
-            <button class="btn-prev">
-              <span class="a11y-hidden">이전 페이지</span>
-            </button>
-            <a class="logo"><div class="img-logo"></div></a>
-            <button class="btn-next">
-              <span class="a11y-hidden">다음 페이지</span>
-            </button>
-          </div>
-        </section>
-        <div class="inner2-2">
-          <article class="account">
-            <p class="account__title">
-              네이버를 더 안전하고 편리하게 이용하세요
-            </p>
-            <a class="account__login"><i></i> 로그인</a>
-            <ul class="account__find">
-              <li>아이디 찾기</li>
-              <li>비밀번호 찾기</li>
-              <li>회원가입</li>
+            </header>
+            <ul class="memo__content">
+              <li class="memo__item">
+                <a href="#">
+                  <span class="item__text item--active">
+                    <i></i><span class="blind">중요메모 표시됨</span>test1
+                  </span>
+                  <span class="item__date">23.08.26</span>
+                </a>
+              </li>
+              <li class="memo__item">
+                <a href="#">
+                  <span class="item__text">
+                    <i></i><span class="blind">중요메모 표시안됨</span>test2
+                  </span>
+                  <span class="item__date">23.08.26</span>
+                </a>
+              </li>
+              <li class="memo__item">
+                <a href="#">
+                  <span class="item__text">
+                    <i></i><span class="blind">중요메모 표시안됨</span>test3
+                    long long long long long long long long text
+                  </span>
+                  <span class="item__date">23.08.26</span>
+                </a>
+              </li>
             </ul>
-          </article>
-          <article class="widgetboard">
-            <div class="widgetboard__title">위젯 보드</div>
-            <section class="widgetboard__memo">
-              <header class="memo__header">
-                <a href="#">메모</a>
-                <div class="memo__lock-button">
-                  <button type="button">
-                    <i>
-                      <span class="blind">메모잠금</span>
-                    </i>
-                    <div class="memo__lock-button-tooltip">메모 잠그기</div>
-                  </button>
-                </div>
-              </header>
-              <ul class="memo__content">
-                <li class="memo__item">
-                  <a href="#">
-                    <span class="item__text item--active">
-                      <i></i><span class="blind">중요메모 표시됨</span>test1
-                    </span>
-                    <span class="item__date">23.08.26</span>
-                  </a>
-                </li>
-                <li class="memo__item">
-                  <a href="#">
-                    <span class="item__text">
-                      <i></i><span class="blind">중요메모 표시안됨</span>test2
-                    </span>
-                    <span class="item__date">23.08.26</span>
-                  </a>
-                </li>
-                <li class="memo__item">
-                  <a href="#">
-                    <span class="item__text">
-                      <i></i><span class="blind">중요메모 표시안됨</span>test3
-                      long long long long long long long long text
-                    </span>
-                    <span class="item__date">23.08.26</span>
-                  </a>
-                </li>
-              </ul>
-              <a href="#" class="memo__new" aria-label="새 메모 쓰기">
-                <span aria-hidden="true">새 메모 쓰기</span>
-              </a>
-            </section>
-          </article>
-        </div>
-      </div>
-    </div>
-  </body>
+            <a href="#" class="memo__new" aria-label="새 메모 쓰기">
+              <span aria-hidden="true">새 메모 쓰기</span>
+            </a>
+          </section>
+        </article>
+      </section>
+    </main>
+  </div>
+</body>
+
 </html>

--- a/seunggyu.html
+++ b/seunggyu.html
@@ -1,93 +1,96 @@
 <!DOCTYPE html>
 <html lang="ko">
-  <head>
-    <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>네이버: 로그인</title>
-    <!-- <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/font-applesdgothicneo@1.0/all.min.css"> -->
-    <link rel = "stylesheet" href = "style/style.css"/>
-  </head>
 
-  <body>
-    <!-- 네이버 로고 -->
-    <header class = "header-wrap">
-        <a href = "index.html" class = "logo">
-          <h1 class = "blind">NAVER</h1>
-        </a>
-    </header>
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>네이버: 로그인</title>
+  <!-- <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/font-applesdgothicneo@1.0/all.min.css"> -->
+  <link rel="stylesheet" href="style/style.css" />
+</head>
 
-    <div class = "content-wrap">
+<body>
+  <!-- 네이버 로고 -->
+  <header class="header-wrap">
+    <a href="index.html" class="logo">
+      <h1 class="blind">NAVER</h1>
+    </a>
+  </header>
+
+  <div class="content-wrap">
     <!-- 모달 컨테이너 -->
-    <div class = "login-wrap">
+    <div class="login-wrap">
       <!-- 메뉴 -->
-        <ul class = "login-wrap__menu-wrap">
-          <li>
-            <a href = "#">
-              <span>ID 로그인</span>
-            </a>
-          </li>
-          <li>
-            <a href = "#">
-              <span>일회용 번호</span>
-            </a>
-          </li>
-          <li>
-            <a href = "#">
-              <span>QR코드</span>
-            </a>
-          </li>
-        </ul>
-      
+      <ul class="login-wrap__menu-wrap">
+        <li>
+          <a href="#">
+            <span>ID 로그인</span>
+          </a>
+        </li>
+        <li>
+          <a href="#">
+            <span>일회용 번호</span>
+          </a>
+        </li>
+        <li>
+          <a href="#">
+            <span>QR코드</span>
+          </a>
+        </li>
+      </ul>
+
       <!-- 아이디 및 비밀번호 입력창 -->
       <!-- 1. 네이버처럼 id랑 pw를 감아서 아이콘 넣어주기 -->
       <!-- 2. calc 사용해서 반응형 컨테이너 만들어주기 -->
-      <form class = "login-form">
-        <div class = "login-form__id-pw-wrap">
-          <label class = "login-form__label-id" for = "user-id" ></label>
-          <input class = "login-form__input-id" type = "text" id = "user-id" placeholder = "아이디">
+      <form class="login-form">
+        <div class="login-form__id-pw-wrap">
+          <label class="login-form__label-id" for="user-id"></label>
+          <input class="login-form__input-id" type="text" id="user-id" placeholder="아이디">
 
-          <label class = "login-form__label-pw" for = "user-pw" ></label>
-          <input class = "login-form__input-pw" type = "text" id = "user-pw" placeholder = "패스워드">
+          <label class="login-form__label-pw" for="user-pw"></label>
+          <input class="login-form__input-pw" type="password" id="user-pw" placeholder="패스워드">
         </div>
 
-        <div class = "checkbox-toggle-wrap">
+        <div class="checkbox-toggle-wrap">
           <!-- 체크박스 -->
-          <div class = "checkbox-toggle-wrap__checkbox-area">
-              <input class = "checkbox-toggle-wrap__login-checkbox blind" type = "checkbox" name = "maintain-login" id = "maintain-login">
-              <label class = "checkbox-toggle-wrap__checkbox-text" for = "maintain-login">로그인 상태 유지</label>
+          <div class="checkbox-toggle-wrap__checkbox-area">
+            <input class="checkbox-toggle-wrap__login-checkbox blind" type="checkbox" name="maintain-login"
+              id="maintain-login">
+            <label class="checkbox-toggle-wrap__checkbox-text" for="maintain-login">로그인 상태 유지</label>
           </div>
 
           <!-- IP보안 토글 슬라이더 -->
-          <div class = "checkbox-toggle-wrap__toggle-area">
-            <label class = "checkbox-toggle-wrap__toggle-text" for = "protect-IP">IP 보안</label>
-            <input class = "checkbox-toggle-wrap__toggle-button" type = "checkbox" name= "protect-IP" id = "protect-IP">
+          <div class="checkbox-toggle-wrap__toggle-area">
+            <label class="checkbox-toggle-wrap__toggle-text" for="protect-IP">IP 보안</label>
+            <input class="checkbox-toggle-wrap__toggle-button" type="checkbox" name="protect-IP" id="protect-IP">
           </div>
         </div>
 
-          <!-- 로그인 버튼 -->
-          <button class = "login-button">
-            <span>로그인</span>
-          </button>
-        </div>
-      </form>
-
-      <!-- 빠른 찾기/가입 -->
-      <div class = "find-wrap">
-        <ul class = "find-wrap__find-inner-wrap">
-          <li class = "find-pw">
-            <a href = "#">비밀번호 찾기</a>
-          </li>
-          <li class = "find-id">
-            <a href = "#">아이디 찾기</a>
-          </li>
-          <li class = "sign-up">
-            <a href = "#">회원가입</a>
-          </li>
-        </ul>
-      </div>
+        <!-- 로그인 버튼 -->
+        <button type="button" class="login-button">
+          <span>로그인</span>
+        </button>
     </div>
+    </form>
 
-    <!-- <footer>추가예정</footer> -->
-  </body>
+    <!-- 빠른 찾기/가입 -->
+    <div class="find-wrap">
+      <ul class="find-wrap__find-inner-wrap">
+        <li class="find-pw">
+          <a href="#">비밀번호 찾기</a>
+        </li>
+        <li class="find-id">
+          <a href="#">아이디 찾기</a>
+        </li>
+        <li class="sign-up">
+          <a href="#">회원가입</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+
+  <!-- <footer>추가예정</footer> -->
+</body>
+
 </html>


### PR DESCRIPTION
### 시맨틱태그, 웹 접근성 고려 

**헤딩태그**
- 네이버 로고 h1 (텍스트 숨김 처리)
- 계정 로그인 h2 (텍스트 숨김 처리)
- 위젯 보드 h2, 메모 h3 
- 로그인 폼 네이버 로고 h1 

**공통**
- div class="inner1" 삭제 
- div class="inner2" -> main 태그로 변경 
- class inner2-1 스타일 삭제
- div class="inner2-2"을 section class="section-aside"로 태그, 클래스 변경

**loginpage** 
- button type 추가
- password에 대한 input type을 password로 수정

**login-form**
- 로그인, 아이디 찾기, 비밀번호 찾기 li에 a태그와 href 속성 추가
- h2 로고에 대한 텍스트 숨김 처리 추가

**serviceList**
- header로 감싸기
- new article 태그를 ul과 li로 변경 

**news__companies**
- a 태그에 href 속성 추가 
- button type 추가
- a class="logo"에  aria-label="네이버 로고" 추가
- article 태그를 ul과 li로 변경 
article 요소는 포럼, 신문기사, 잡지, 블러그 항목, 게시판 글 등 콘텐츠의 독립적인 항목을 나타내기 때문에 현재 a요소만 포함된 영역에 적절하지 않아 변경

